### PR TITLE
3 test singleframemodel

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,7 +3,8 @@ DATA_ROOT = "/dtu/datasets1/02516/ufc10"
 #DATA_ROOT = "/dtu/datasets1/02516/ucf101_noleakage" #til senere oppagve
 
 # models
-MODEL_NAMES = ["per_frame_agg", "early_fusion", "late_fusion", "c3d"]
+MODEL_NAMES = ["per_frame_agg"]
+# MODEL_NAMES = ["per_frame_agg", "early_fusion", "late_fusion", "c3d"]
 
 # antall klasser i datasettet
 NUM_CLASSES = 10

--- a/config.py
+++ b/config.py
@@ -2,3 +2,8 @@ NUM_CLASSES = 10
 TRAINABLE_BLOCKS = 0
 FREEZE_BACKBONE = True
 NUM_EPOCHS = 1
+
+DATA_ROOT = "placeholder_for_data_root"  # sett riktig sti i config.py
+N_FRAMES = 10
+BATCH_SIZE = 64
+NUM_WORKERS = 8

--- a/config.py
+++ b/config.py
@@ -1,11 +1,22 @@
-NUM_CLASSES = 10
-TRAINABLE_BLOCKS = 0
-FREEZE_BACKBONE = True
-EPOCHS = 1
+# datasett path
+DATA_ROOT = "/dtu/datasets1/02516/ufc10"
+#DATA_ROOT = "/dtu/datasets1/02516/ucf101_noleakage" #til senere oppagve
 
-DATA_ROOT = "/dtu/datasets1/02516/ucf10"
-#DATA_ROOT = "/dtu/datasets1/02516/ucf101_noleakage"
+# models
+MODEL_NAMES = ["per_frame_agg", "early_fusion", "late_fusion", "c3d"]
+
+# antall klasser i datasettet
+NUM_CLASSES = 10
+
+# Hvor mange blokker i backbone som skal trenes (0 = frys alt)
+TRAINABLE_BLOCKS = 0
+
+# Hvis True: frys backbone og tren kun klassifiseringshodet
+FREEZE_BACKBONE = True
+
+# treningsparametre
 N_FRAMES = 10
 BATCH_SIZE = 64
-NUM_WORKERS = 8
+NUM_WORKERS = 4
 LR = 1e-4
+EPOCHS = 1

--- a/config.py
+++ b/config.py
@@ -1,9 +1,11 @@
+import os
+
 NUM_CLASSES = 10
 TRAINABLE_BLOCKS = 0
 FREEZE_BACKBONE = True
 NUM_EPOCHS = 1
 
-DATA_ROOT = "placeholder_for_data_root"  # sett riktig sti i config.py
+DATA_ROOT = os.path.expanduser("~/prosjekt_2/ufc10")  # sett riktig sti i config.py
 N_FRAMES = 10
 BATCH_SIZE = 64
 NUM_WORKERS = 8

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 # datasett path
 DATA_ROOT = "/dtu/datasets1/02516/ufc10"
-#DATA_ROOT = "/dtu/datasets1/02516/ucf101_noleakage" #til senere oppagve
+# DATA_ROOT = "/dtu/datasets1/02516/ucf101_noleakage" #til senere oppagve
 
 # models
 MODEL_NAMES = ["per_frame_agg"]

--- a/config.py
+++ b/config.py
@@ -1,11 +1,11 @@
-import os
-
 NUM_CLASSES = 10
 TRAINABLE_BLOCKS = 0
 FREEZE_BACKBONE = True
-NUM_EPOCHS = 1
+EPOCHS = 1
 
-DATA_ROOT = os.path.expanduser("~/prosjekt_2/ufc10")  # sett riktig sti i config.py
+DATA_ROOT = "/dtu/datasets1/02516/ucf10"
+#DATA_ROOT = "/dtu/datasets1/02516/ucf101_noleakage"
 N_FRAMES = 10
 BATCH_SIZE = 64
 NUM_WORKERS = 8
+LR = 1e-4

--- a/data
+++ b/data
@@ -1,1 +1,0 @@
-/zhome/c9/a/223944/prosjekt_2/ufc10

--- a/github/workflows/ci.yml
+++ b/github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  lint-and-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install ruff black
+      # Lint (fanger kodefeil, ubrukte imports, osv.)
+      - run: ruff check .
+      # Format-sjekk (sjekker at black er kjørt)
+      - run: black --check .
+   

--- a/jobscript.sh
+++ b/jobscript.sh
@@ -28,4 +28,4 @@
 source ~/venv_1/bin/activate
 
 ### -------- run your script -------------------
-python -m src.smoke_tests
+python -m src.main

--- a/jobscript.sh
+++ b/jobscript.sh
@@ -28,4 +28,4 @@
 source ~/venv_1/bin/activate
 
 ### -------- run your script -------------------
-python -m src.main
+python -m src.smoke_tests

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -1,2 +1,3 @@
 from .datasets import FrameImageDataset, FrameVideoDataset
+
 __all__ = ["FrameImageDataset", "FrameVideoDataset"]

--- a/src/datasets/__init__.py
+++ b/src/datasets/__init__.py
@@ -1,0 +1,2 @@
+from .datasets import FrameImageDataset, FrameVideoDataset
+__all__ = ["FrameImageDataset", "FrameVideoDataset"]

--- a/src/datasets/datasets.py
+++ b/src/datasets/datasets.py
@@ -1,4 +1,3 @@
-# src/data/datasets.py
 from glob import glob
 from pathlib import Path
 import os
@@ -6,7 +5,7 @@ import pandas as pd
 from PIL import Image
 import torch
 from torchvision import transforms as T
-from config import DATA_ROOT, N_FRAMES  # legg til i config.py
+from config import DATA_ROOT, N_FRAMES  
 
 class FrameImageDataset(torch.utils.data.Dataset):
     def __init__(self, root_dir=DATA_ROOT, split='train', transform=None):

--- a/src/datasets/datasets.py
+++ b/src/datasets/datasets.py
@@ -5,46 +5,55 @@ import pandas as pd
 from PIL import Image
 import torch
 from torchvision import transforms as T
-from config import DATA_ROOT, N_FRAMES  
+from config import DATA_ROOT, N_FRAMES
+
 
 class FrameImageDataset(torch.utils.data.Dataset):
-    def __init__(self, root_dir=DATA_ROOT, split='train', transform=None):
+    def __init__(self, root_dir=DATA_ROOT, split="train", transform=None):
         self.root = Path(root_dir)
-        self.frame_paths = sorted(glob(f'{self.root}/frames/{split}/*/*/*.jpg'))
-        self.df = pd.read_csv(f'{self.root}/metadata/{split}.csv')
+        self.frame_paths = sorted(glob(f"{self.root}/frames/{split}/*/*/*.jpg"))
+        self.df = pd.read_csv(f"{self.root}/metadata/{split}.csv")
         self.split = split
         self.transform = transform or T.ToTensor()
 
-    def __len__(self): return len(self.frame_paths)
+    def __len__(self):
+        return len(self.frame_paths)
 
     def __getitem__(self, idx):
         frame_path = self.frame_paths[idx]
         video_name = Path(frame_path).parent.name
-        label = self.df.loc[self.df['video_name'] == video_name, 'label'].item()
+        label = self.df.loc[self.df["video_name"] == video_name, "label"].item()
         img = Image.open(frame_path).convert("RGB")
         return self.transform(img), label
 
 
 class FrameVideoDataset(torch.utils.data.Dataset):
-    def __init__(self, root_dir=DATA_ROOT, split='train', transform=None, stack_frames=True):
+    def __init__(
+        self, root_dir=DATA_ROOT, split="train", transform=None, stack_frames=True
+    ):
         self.root = Path(root_dir)
-        self.video_paths = sorted(glob(f'{self.root}/videos/{split}/*/*.avi'))
-        self.df = pd.read_csv(f'{self.root}/metadata/{split}.csv')
+        self.video_paths = sorted(glob(f"{self.root}/videos/{split}/*/*.avi"))
+        self.df = pd.read_csv(f"{self.root}/metadata/{split}.csv")
         self.split = split
         self.transform = transform or T.ToTensor()
         self.stack_frames = stack_frames
         self.n_sampled_frames = N_FRAMES
 
-    def __len__(self): return len(self.video_paths)
+    def __len__(self):
+        return len(self.video_paths)
 
     def __getitem__(self, idx):
         video_path = self.video_paths[idx]
         video_name = Path(video_path).stem
-        label = self.df.loc[self.df['video_name'] == video_name, 'label'].item()
-        frames_dir = video_path.replace('/videos/', '/frames/').replace('.avi','')
-        frames = [self.transform(Image.open(os.path.join(frames_dir, f'frame_{i}.jpg')).convert('RGB'))
-                  for i in range(1, self.n_sampled_frames + 1)]
+        label = self.df.loc[self.df["video_name"] == video_name, "label"].item()
+        frames_dir = video_path.replace("/videos/", "/frames/").replace(".avi", "")
+        frames = [
+            self.transform(
+                Image.open(os.path.join(frames_dir, f"frame_{i}.jpg")).convert("RGB")
+            )
+            for i in range(1, self.n_sampled_frames + 1)
+        ]
         if self.stack_frames:
             # [T,C,H,W] -> [C,T,H,W]
-            return torch.stack(frames).permute(1,0,2,3), label
+            return torch.stack(frames).permute(1, 0, 2, 3), label
         return frames, label

--- a/src/datasets/datasets.py
+++ b/src/datasets/datasets.py
@@ -1,0 +1,51 @@
+# src/data/datasets.py
+from glob import glob
+from pathlib import Path
+import os
+import pandas as pd
+from PIL import Image
+import torch
+from torchvision import transforms as T
+from config import DATA_ROOT, N_FRAMES  # legg til i config.py
+
+class FrameImageDataset(torch.utils.data.Dataset):
+    def __init__(self, root_dir=DATA_ROOT, split='train', transform=None):
+        self.root = Path(root_dir)
+        self.frame_paths = sorted(glob(f'{self.root}/frames/{split}/*/*/*.jpg'))
+        self.df = pd.read_csv(f'{self.root}/metadata/{split}.csv')
+        self.split = split
+        self.transform = transform or T.ToTensor()
+
+    def __len__(self): return len(self.frame_paths)
+
+    def __getitem__(self, idx):
+        frame_path = self.frame_paths[idx]
+        video_name = Path(frame_path).parent.name
+        label = self.df.loc[self.df['video_name'] == video_name, 'label'].item()
+        img = Image.open(frame_path).convert("RGB")
+        return self.transform(img), label
+
+
+class FrameVideoDataset(torch.utils.data.Dataset):
+    def __init__(self, root_dir=DATA_ROOT, split='train', transform=None, stack_frames=True):
+        self.root = Path(root_dir)
+        self.video_paths = sorted(glob(f'{self.root}/videos/{split}/*/*.avi'))
+        self.df = pd.read_csv(f'{self.root}/metadata/{split}.csv')
+        self.split = split
+        self.transform = transform or T.ToTensor()
+        self.stack_frames = stack_frames
+        self.n_sampled_frames = N_FRAMES
+
+    def __len__(self): return len(self.video_paths)
+
+    def __getitem__(self, idx):
+        video_path = self.video_paths[idx]
+        video_name = Path(video_path).stem
+        label = self.df.loc[self.df['video_name'] == video_name, 'label'].item()
+        frames_dir = video_path.replace('/videos/', '/frames/').replace('.avi','')
+        frames = [self.transform(Image.open(os.path.join(frames_dir, f'frame_{i}.jpg')).convert('RGB'))
+                  for i in range(1, self.n_sampled_frames + 1)]
+        if self.stack_frames:
+            # [T,C,H,W] -> [C,T,H,W]
+            return torch.stack(frames).permute(1,0,2,3), label
+        return frames, label

--- a/src/main.py
+++ b/src/main.py
@@ -1,17 +1,17 @@
 import os
 import sys
-import torch
 
 # legg til prosjektroten i sys.path slik at src.* import fungerer
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 from config import MODEL_NAME
 from src.utils.training_loop import main as train_frames
+
 # når du får early/late/3d kan du legge til flere:
 # from src.utils.video_training import main as train_videos
 
 if __name__ == "__main__":
-    model_name = MODEL_NAME if 'MODEL_NAME' in locals() else "per_frame_agg"
+    model_name = MODEL_NAME if "MODEL_NAME" in locals() else "per_frame_agg"
     print(f"[INFO] Starter trening med modell: {model_name}")
 
     if model_name == "per_frame_agg":

--- a/src/main.py
+++ b/src/main.py
@@ -8,15 +8,12 @@
 import sys
 import os
 import torch.nn as nn
+import torch.nn as nn
+from config import NUM_CLASSES
+from src.utils.model_factory import select_model
 
 # legg til prosjektroten i sys.path slik at config.py kan importeres
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
-
-import torch.nn as nn
-
-from config import NUM_CLASSES
-
-from src.utils.model_factory import select_model
 
 # #change model name here to test other models
 model = select_model("per_frame_agg", num_classes=NUM_CLASSES)

--- a/src/main.py
+++ b/src/main.py
@@ -1,29 +1,20 @@
-# to initialize the run
-# ◦ Parser kommandolinjeargumenter (eller laster inn config.yaml).
-# ◦ Velger riktig modell (f.eks. basert på et argument som model_name='LateFusion').
-# ◦ Initialiserer datasett og dataloadere ved hjelp av datasets.py.
-# ◦ Definerer tapfunksjon (f.eks. nn.CrossEntropyLoss) og optimalisator (f.eks. Adam eller SGD+Momentum).
-# ◦ Kaller treningsfunksjonen fra utils/training_loop.py.
-
-import sys
 import os
-import torch.nn as nn
-import torch.nn as nn
-from config import NUM_CLASSES
-from src.utils.model_factory import select_model
+import sys
+import torch
 
-# legg til prosjektroten i sys.path slik at config.py kan importeres
+# legg til prosjektroten i sys.path slik at src.* import fungerer
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-# #change model name here to test other models
-model = select_model("per_frame_agg", num_classes=NUM_CLASSES)
+from config import MODEL_NAME
+from src.utils.training_loop import main as train_frames
+# når du får early/late/3d kan du legge til flere:
+# from src.utils.video_training import main as train_videos
 
+if __name__ == "__main__":
+    model_name = MODEL_NAME if 'MODEL_NAME' in locals() else "per_frame_agg"
+    print(f"[INFO] Starter trening med modell: {model_name}")
 
-class VideoModel(nn.Module):
-    def __init__(self):
-        super(VideoModel, self).__init__()
-        # Modellarkitekturdefinisjon her
-
-    def forward(self, x):
-        # Fremoverpasseringslogikk her
-        return x
+    if model_name == "per_frame_agg":
+        train_frames(model_name=model_name)
+    else:
+        raise NotImplementedError(f"Treningsløype for {model_name} er ikke laget ennå.")

--- a/src/smoke_tests.py
+++ b/src/smoke_tests.py
@@ -1,8 +1,11 @@
+import os, sys
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
 import torch
 from src.data.datasets import FrameVideoDataset
 from src.models.models import SingleFrameModel
 from src.utils.video_utils import logits_mean_over_time
-from src.utils.transforms import get_single_frame_transform
+from utils.transforms import get_single_frame_transform
 from config import DATA_ROOT, NUM_CLASSES, N_FRAMES
 
 def main():

--- a/src/smoke_tests.py
+++ b/src/smoke_tests.py
@@ -1,16 +1,16 @@
-
 import torch
-from src.datasets.datasets import FrameVideoDataset, FrameImageDataset
+from src.datasets.datasets import FrameImageDataset
 from src.models.models import SingleFrameModel
 from src.utils.video_utils import logits_mean_over_time
 from src.utils.transforms import get_single_frame_transform
-from config import DATA_ROOT, NUM_CLASSES, N_FRAMES
+from config import DATA_ROOT, NUM_CLASSES
+
 
 def main():
     print(f"[INFO] Tester dataset fra {DATA_ROOT}")
     transform = get_single_frame_transform()
     ds = FrameImageDataset(root_dir=DATA_ROOT, split="train", transform=transform)
-    #ds = FrameVideoDataset(root_dir=DATA_ROOT, split="train", transform=transform, stack_frames=True)
+    # ds = FrameVideoDataset(root_dir=DATA_ROOT, split="train", transform=transform, stack_frames=True)
     print(f"Antall videoer i train: {len(ds)}")
 
     # hent én video
@@ -28,6 +28,7 @@ def main():
     print(f"Output logits shape: {logits.shape}")
 
     print("[OK] Smoke-test fullført uten feil ✅")
+
 
 if __name__ == "__main__":
     main()

--- a/src/smoke_tests.py
+++ b/src/smoke_tests.py
@@ -1,8 +1,8 @@
 import torch
-from src.data.datasets import FrameVideoDataset
-from src.models.models import SingleFrameModel
-from src.utils.video_utils import logits_mean_over_time
-from src.utils.transforms import get_single_frame_transform
+from data.datasets import FrameVideoDataset
+from models.models import SingleFrameModel
+from utils.video_utils import logits_mean_over_time
+from utils.transforms import get_single_frame_transform
 from config import DATA_ROOT, NUM_CLASSES, N_FRAMES
 
 def main():

--- a/src/smoke_tests.py
+++ b/src/smoke_tests.py
@@ -1,0 +1,31 @@
+import torch
+from src.data.datasets import FrameVideoDataset
+from src.models.models import SingleFrameModel
+from src.utils.video_utils import logits_mean_over_time
+from src.utils.transforms import get_single_frame_transform
+from config import DATA_ROOT, NUM_CLASSES, N_FRAMES
+
+def main():
+    print(f"[INFO] Tester dataset fra {DATA_ROOT}")
+    transform = get_single_frame_transform()
+    ds = FrameVideoDataset(root_dir=DATA_ROOT, split="train", transform=transform)
+    print(f"Antall videoer i train: {len(ds)}")
+
+    # hent én video
+    x, y = ds[0]
+    print(f"Video shape: {x.shape if isinstance(x, torch.Tensor) else len(x)} frames")
+    print(f"Label: {y}")
+
+    # initier modell
+    model = SingleFrameModel(num_classes=NUM_CLASSES)
+    model.eval()
+
+    # kjør forward-pass (enten med stackede frames eller liste)
+    with torch.no_grad():
+        logits = logits_mean_over_time(model, x)
+    print(f"Output logits shape: {logits.shape}")
+
+    print("[OK] Smoke-test fullført uten feil ✅")
+
+if __name__ == "__main__":
+    main()

--- a/src/smoke_tests.py
+++ b/src/smoke_tests.py
@@ -1,8 +1,6 @@
-import os, sys
-sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import torch
-from src.data.datasets import FrameVideoDataset
+from src.datasets.datasets import FrameVideoDataset, FrameImageDataset
 from src.models.models import SingleFrameModel
 from src.utils.video_utils import logits_mean_over_time
 from src.utils.transforms import get_single_frame_transform
@@ -11,7 +9,8 @@ from config import DATA_ROOT, NUM_CLASSES, N_FRAMES
 def main():
     print(f"[INFO] Tester dataset fra {DATA_ROOT}")
     transform = get_single_frame_transform()
-    ds = FrameVideoDataset(root_dir=DATA_ROOT, split="train", transform=transform)
+    ds = FrameImageDataset(root_dir=DATA_ROOT, split="train", transform=transform)
+    #ds = FrameVideoDataset(root_dir=DATA_ROOT, split="train", transform=transform, stack_frames=True)
     print(f"Antall videoer i train: {len(ds)}")
 
     # hent én video

--- a/src/utils/model_factory.py
+++ b/src/utils/model_factory.py
@@ -1,4 +1,6 @@
-from src. models.models import SingleFrameModel  # , LateFusionModel, EarlyFusionModel, C3D
+from src.models.models import (
+    SingleFrameModel,
+)  # , LateFusionModel, EarlyFusionModel, C3D
 
 
 def select_model(model_name: str, num_classes: int):

--- a/src/utils/training_loop.py
+++ b/src/utils/training_loop.py
@@ -1,31 +1,31 @@
-# src/utils/training_loop.py
-import os
 import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
-from src.models.models import SingleFrameModel
+from src.utils.model_factory import select_model
 from src.utils.transforms import get_single_frame_transform
-from src.data.datasets import FrameImageDataset
-from config import DATA_ROOT, NUM_CLASSES, LR, NUM_WORKERS, BATCH_SIZE, EPOCHS   # <-- Hent fra config, ikke hardkod
+from src.datasets.datasets import FrameImageDataset  # sørg for riktig path
+from config import DATA_ROOT, NUM_CLASSES, LR, NUM_WORKERS, BATCH_SIZE, EPOCHS
 
 
 def train_one_epoch(model, loader, opt, device):
     model.train()
     total = correct = 0
     loss_sum = 0.0
-    for x, y in loader:  # per-frame: x=[B,3,H,W]
+    for x, y in loader:
         x, y = x.to(device), y.to(device)
         logits = model(x)
         loss = F.cross_entropy(logits, y)
         opt.zero_grad(set_to_none=True)
         loss.backward()
         opt.step()
+
         pred = logits.argmax(1)
         total += y.numel()
         correct += (pred == y).sum().item()
         loss_sum += loss.item() * y.size(0)
-    return loss_sum/total, correct/total
+    return loss_sum / total, correct / total
+
 
 @torch.no_grad()
 def evaluate_frames(model, loader, device):
@@ -36,39 +36,39 @@ def evaluate_frames(model, loader, device):
         x, y = x.to(device), y.to(device)
         logits = model(x)
         loss = F.cross_entropy(logits, y)
+
         pred = logits.argmax(1)
         total += y.numel()
         correct += (pred == y).sum().item()
         loss_sum += loss.item() * y.size(0)
-    return loss_sum/total, correct/total
+    return loss_sum / total, correct / total
 
-def main():
-    device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    # Hvis transform-funksjonen din ikke bruker split, kall uten argumenter:
+def main(model_name="per_frame_agg"):
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    print(f"[INFO] Device: {device}")
+
+    # Data og transforms
     tf = get_single_frame_transform()
-
     train_ds = FrameImageDataset(root_dir=DATA_ROOT, split="train", transform=tf)
-    val_ds   = FrameImageDataset(root_dir=DATA_ROOT, split="val",   transform=tf)
+    val_ds = FrameImageDataset(root_dir=DATA_ROOT, split="val", transform=tf)
 
     pin = torch.cuda.is_available()
     train_loader = DataLoader(train_ds, batch_size=BATCH_SIZE, shuffle=True,
                               num_workers=NUM_WORKERS, pin_memory=pin)
-    val_loader   = DataLoader(val_ds,   batch_size=BATCH_SIZE, shuffle=False,
-                              num_workers=NUM_WORKERS, pin_memory=pin)
+    val_loader = DataLoader(val_ds, batch_size=BATCH_SIZE, shuffle=False,
+                            num_workers=NUM_WORKERS, pin_memory=pin)
 
-    model = SingleFrameModel(num_classes=NUM_CLASSES, trainable_blocks=0).to(device)
+    # Modell fra factory
+    model = select_model(model_name, num_classes=NUM_CLASSES).to(device)
     opt = torch.optim.AdamW([p for p in model.parameters() if p.requires_grad], lr=LR)
 
     best_va = 0.0
-    for e in range(1, EPOCHS+1):
+    for e in range(1, EPOCHS + 1):
         tr_loss, tr_acc = train_one_epoch(model, train_loader, opt, device)
         va_loss, va_acc = evaluate_frames(model, val_loader, device)
-        print(f"Epoch {e:02d} | train {tr_acc:.3f} ({tr_loss:.4f}) | val {va_acc:.3f} ({va_loss:.4f})")
+        print(f"Epoch {e:02d} | train {tr_acc:.3f} ({tr_loss:.4f}) | "
+              f"val {va_acc:.3f} ({va_loss:.4f})")
         best_va = max(best_va, va_acc)
 
-    print(f"Best val acc (per-frame): {best_va:.3f}")
-
-if __name__ == "__main__":
-    main()
-
+    print(f"[INFO] Best val acc ({model_name}): {best_va:.3f}")

--- a/src/utils/training_loop.py
+++ b/src/utils/training_loop.py
@@ -7,13 +7,8 @@ from torch.utils.data import DataLoader
 from src.models.models import SingleFrameModel
 from src.utils.transforms import get_single_frame_transform
 from src.data.datasets import FrameImageDataset
-from config import DATA_ROOT, NUM_CLASSES   # <-- Hent fra config, ikke hardkod
+from config import DATA_ROOT, NUM_CLASSES, LR, NUM_WORKERS, BATCH_SIZE, EPOCHS   # <-- Hent fra config, ikke hardkod
 
-# --- KONFIG ---
-BATCH_SIZE = 64
-EPOCHS = 5
-LR = 1e-4
-NUM_WORKERS = 4
 
 def train_one_epoch(model, loader, opt, device):
     model.train()

--- a/src/utils/training_loop.py
+++ b/src/utils/training_loop.py
@@ -54,10 +54,20 @@ def main(model_name="per_frame_agg"):
     val_ds = FrameImageDataset(root_dir=DATA_ROOT, split="val", transform=tf)
 
     pin = torch.cuda.is_available()
-    train_loader = DataLoader(train_ds, batch_size=BATCH_SIZE, shuffle=True,
-                              num_workers=NUM_WORKERS, pin_memory=pin)
-    val_loader = DataLoader(val_ds, batch_size=BATCH_SIZE, shuffle=False,
-                            num_workers=NUM_WORKERS, pin_memory=pin)
+    train_loader = DataLoader(
+        train_ds,
+        batch_size=BATCH_SIZE,
+        shuffle=True,
+        num_workers=NUM_WORKERS,
+        pin_memory=pin,
+    )
+    val_loader = DataLoader(
+        val_ds,
+        batch_size=BATCH_SIZE,
+        shuffle=False,
+        num_workers=NUM_WORKERS,
+        pin_memory=pin,
+    )
 
     # Modell fra factory
     model = select_model(model_name, num_classes=NUM_CLASSES).to(device)
@@ -67,8 +77,10 @@ def main(model_name="per_frame_agg"):
     for e in range(1, EPOCHS + 1):
         tr_loss, tr_acc = train_one_epoch(model, train_loader, opt, device)
         va_loss, va_acc = evaluate_frames(model, val_loader, device)
-        print(f"Epoch {e:02d} | train {tr_acc:.3f} ({tr_loss:.4f}) | "
-              f"val {va_acc:.3f} ({va_loss:.4f})")
+        print(
+            f"Epoch {e:02d} | train {tr_acc:.3f} ({tr_loss:.4f}) | "
+            f"val {va_acc:.3f} ({va_loss:.4f})"
+        )
         best_va = max(best_va, va_acc)
 
     print(f"[INFO] Best val acc ({model_name}): {best_va:.3f}")

--- a/src/utils/training_loop.py
+++ b/src/utils/training_loop.py
@@ -1,62 +1,35 @@
-# src/train_video_mean.py
+# src/utils/training_loop.py
+import os
 import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
+
 from src.models.models import SingleFrameModel
 from src.utils.transforms import get_single_frame_transform
-from video_utils import logits_mean_over_time
-import os
+from src.data.datasets import FrameImageDataset
+from config import DATA_ROOT, NUM_CLASSES   # <-- Hent fra config, ikke hardkod
 
-
-frames_root = os.path.expanduser("~/prosjekt_2/ufc10/frames")
-train_dir = os.path.join(frames_root, "train")
-val_dir   = os.path.join(frames_root, "val")
-test_dir  = os.path.join(frames_root, "test")
-
+# --- KONFIG ---
 BATCH_SIZE = 64
-EPOCHS = 1
+EPOCHS = 5
 LR = 1e-4
+NUM_WORKERS = 4
 
-
-# ---------- Aggregator (for senere video-evaluering) ----------
-@torch.no_grad()
-def aggregate_logits_mean(logits_list):
-    """Tar en liste/stack av logits [T, num_classes] og returnerer snittet [num_classes]."""
-    return torch.stack(logits_list, dim=0).mean(dim=0)
-
-# ---------- Forward-adapter ----------
-def forward_batch(model, x, mode="per_frame"):
-    """
-    Ett felles inngangspunkt til modellen.
-    Nå: mode='per_frame' (x: [B,C,H,W]) -> model(x).
-    Senere: mode='sequence' (x: [C,T,H,W] eller liste med T bilder) -> kall sekvens-agg.
-    """
-    if mode == "per_frame":
-        return model(x)  # [B, K]
-    else:
-        raise NotImplementedError("Legg til sekvensvei her når du går til early/late fusion.")
-
-# ---------- Train / Eval ----------
 def train_one_epoch(model, loader, opt, device):
     model.train()
     total = correct = 0
     loss_sum = 0.0
-
-    for x, y in loader:                 # x: [B,C,H,W] (per-frame)
+    for x, y in loader:  # per-frame: x=[B,3,H,W]
         x, y = x.to(device), y.to(device)
-
-        logits = forward_batch(model, x, mode="per_frame")
+        logits = model(x)
         loss = F.cross_entropy(logits, y)
-
         opt.zero_grad(set_to_none=True)
         loss.backward()
         opt.step()
-
         pred = logits.argmax(1)
-        total   += y.numel()
+        total += y.numel()
         correct += (pred == y).sum().item()
         loss_sum += loss.item() * y.size(0)
-
     return loss_sum/total, correct/total
 
 @torch.no_grad()
@@ -64,36 +37,32 @@ def evaluate_frames(model, loader, device):
     model.eval()
     total = correct = 0
     loss_sum = 0.0
-
     for x, y in loader:
         x, y = x.to(device), y.to(device)
-        logits = forward_batch(model, x, mode="per_frame")
+        logits = model(x)
         loss = F.cross_entropy(logits, y)
-
         pred = logits.argmax(1)
-        total   += y.numel()
+        total += y.numel()
         correct += (pred == y).sum().item()
         loss_sum += loss.item() * y.size(0)
-
     return loss_sum/total, correct/total
 
 def main():
     device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    # Hvis transform-funksjonen din ikke bruker split, kall uten argumenter:
     tf = get_single_frame_transform()
 
-    # Per-frame datasett (ImageFolder går rekursivt under klasse-mapper)
-    train_ds = ImageFolder(root=train_dir, transform=tf)
-    val_ds   = ImageFolder(root=val_dir,   transform=tf)
-
-    print("Classes:", train_ds.classes)
+    train_ds = FrameImageDataset(root_dir=DATA_ROOT, split="train", transform=tf)
+    val_ds   = FrameImageDataset(root_dir=DATA_ROOT, split="val",   transform=tf)
 
     pin = torch.cuda.is_available()
     train_loader = DataLoader(train_ds, batch_size=BATCH_SIZE, shuffle=True,
-                              num_workers=4, pin_memory=pin)
+                              num_workers=NUM_WORKERS, pin_memory=pin)
     val_loader   = DataLoader(val_ds,   batch_size=BATCH_SIZE, shuffle=False,
-                              num_workers=4, pin_memory=pin)
+                              num_workers=NUM_WORKERS, pin_memory=pin)
 
-    model = SingleFrameModel(num_classes=len(train_ds.classes), trainable_blocks=0).to(device)
+    model = SingleFrameModel(num_classes=NUM_CLASSES, trainable_blocks=0).to(device)
     opt = torch.optim.AdamW([p for p in model.parameters() if p.requires_grad], lr=LR)
 
     best_va = 0.0
@@ -107,3 +76,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/src/utils/video_utils.py
+++ b/src/utils/video_utils.py
@@ -1,15 +1,69 @@
+# src/utils/video_utils.py
 import torch
 
+@torch.no_grad()
+def logits_mean_over_time(model, x, *, batch_size: int = 16):
+    """
+    Returnerer [B,K]. Støtter:
+      - list/tuple av T frames [C,H,W] eller [B,C,H,W]
+      - 3D: [C,H,W] (enkeltbilde)
+      - 4D: [T,C,H,W] ELLER [C,T,H,W] ELLER [B,C,H,W]
+      - 5D: [B,C,T,H,W]
+    """
+    def _as_batched_frames(t):
+        # t: [C,H,W] -> [1,C,H,W]
+        if isinstance(t, torch.Tensor) and t.dim() == 3:
+            return t.unsqueeze(0)
+        return t  # antas allerede [B,C,H,W]
 
-def logits_mean_over_time(model, x):
-    """x: [B,C,T,H,W] eller list med T tensors [B,C,H,W]"""
+    # 1) Liste/tuple av T frames
     if isinstance(x, (list, tuple)):
-        # liste av T frames: [B,C,H,W] hver
-        logits_t = [model(f) for f in x]  # T x [B,K]
-        return torch.stack(logits_t, dim=1).mean(1)  # [B,K]
-    else:
-        # stacket: [B,C,T,H,W] -> [B*T, C, H, W]
+        frames = [ _as_batched_frames(f) for f in x ]  # hver [B?,C,H,W]
+        # Samle til [sumB, C, H, W] for effektiv fwd:
+        fb = torch.cat(frames, dim=0) if frames and frames[0].dim() == 4 else torch.stack(frames, dim=0)
+        # Hvis stack via stack([...]) ga [T,1,C,H,W] -> gjør til [T,C,H,W]
+        if fb.dim() == 5 and fb.shape[1] == 1:
+            fb = fb.squeeze(1)
+        # Nå forventer vi enten [T,C,H,W] eller [B,C,H,W]
+        if fb.dim() == 4 and fb.shape[0] != frames[0].shape[0]:  # [T,C,H,W]
+            # kjør i minibatcher over T
+            T = fb.shape[0]
+            logits_list = []
+            for s in range(0, T, batch_size):
+                logits_list.append(model(fb[s:s+batch_size]))  # [t,C,H,W] -> [t,K]
+            logits_t = torch.cat(logits_list, dim=0).unsqueeze(0)  # [1,T,K]
+            return logits_t.mean(1)  # [1,K]
+        else:
+            # antas [B,C,H,W] (allerede batchet); behandle som enkelt “frame batch”
+            return model(fb)
+
+    # 2) 5D: [B,C,T,H,W]
+    if isinstance(x, torch.Tensor) and x.dim() == 5:
         B, C, T, H, W = x.shape
-        x_bt = x.permute(0, 2, 1, 3, 4).reshape(B * T, C, H, W)
-        logits_bt = model(x_bt)  # [B*T,K]
-        return logits_bt.view(B, T, -1).mean(1)  # [B,K]
+        x_bt = x.permute(0, 2, 1, 3, 4).reshape(B*T, C, H, W)
+        logits_bt = []
+        for s in range(0, B*T, batch_size):
+            logits_bt.append(model(x_bt[s:s+batch_size]))  # [bs,K]
+        logits_bt = torch.cat(logits_bt, dim=0).view(B, T, -1)  # [B,T,K]
+        return logits_bt.mean(1)  # [B,K]
+
+    # 3) 4D: kan være [B,C,H,W] ELLER [T,C,H,W] ELLER [C,T,H,W]
+    if isinstance(x, torch.Tensor) and x.dim() == 4:
+        B_or_T, C, H, W = x.shape
+        # Heuristikk: hvis B_or_T er lite (typ <= 10) og C i {1,3}, behandle som T
+        if C in (1, 3) and B_or_T > 1 and B_or_T <= 64:
+            # anta [T,C,H,W]
+            T = B_or_T
+            logits_list = []
+            for s in range(0, T, batch_size):
+                logits_list.append(model(x[s:s+batch_size]))  # [bs,K]
+            logits_t = torch.cat(logits_list, dim=0).unsqueeze(0)  # [1,T,K]
+            return logits_t.mean(1)  # [1,K]
+        # ellers anta [B,C,H,W]
+        return model(x)  # [B,K]
+
+    # 4) 3D: [C,H,W] -> legg til batch
+    if isinstance(x, torch.Tensor) and x.dim() == 3:
+        return model(x.unsqueeze(0))  # [1,K]
+
+    raise ValueError(f"Ukjent input-shape til logits_mean_over_time: {getattr(x, 'shape', type(x))}")

--- a/src/utils/video_utils.py
+++ b/src/utils/video_utils.py
@@ -1,6 +1,7 @@
 # src/utils/video_utils.py
 import torch
 
+
 @torch.no_grad()
 def logits_mean_over_time(model, x, *, batch_size: int = 16):
     """
@@ -10,6 +11,7 @@ def logits_mean_over_time(model, x, *, batch_size: int = 16):
       - 4D: [T,C,H,W] ELLER [C,T,H,W] ELLER [B,C,H,W]
       - 5D: [B,C,T,H,W]
     """
+
     def _as_batched_frames(t):
         # t: [C,H,W] -> [1,C,H,W]
         if isinstance(t, torch.Tensor) and t.dim() == 3:
@@ -18,9 +20,13 @@ def logits_mean_over_time(model, x, *, batch_size: int = 16):
 
     # 1) Liste/tuple av T frames
     if isinstance(x, (list, tuple)):
-        frames = [ _as_batched_frames(f) for f in x ]  # hver [B?,C,H,W]
+        frames = [_as_batched_frames(f) for f in x]  # hver [B?,C,H,W]
         # Samle til [sumB, C, H, W] for effektiv fwd:
-        fb = torch.cat(frames, dim=0) if frames and frames[0].dim() == 4 else torch.stack(frames, dim=0)
+        fb = (
+            torch.cat(frames, dim=0)
+            if frames and frames[0].dim() == 4
+            else torch.stack(frames, dim=0)
+        )
         # Hvis stack via stack([...]) ga [T,1,C,H,W] -> gjør til [T,C,H,W]
         if fb.dim() == 5 and fb.shape[1] == 1:
             fb = fb.squeeze(1)
@@ -30,7 +36,7 @@ def logits_mean_over_time(model, x, *, batch_size: int = 16):
             T = fb.shape[0]
             logits_list = []
             for s in range(0, T, batch_size):
-                logits_list.append(model(fb[s:s+batch_size]))  # [t,C,H,W] -> [t,K]
+                logits_list.append(model(fb[s : s + batch_size]))  # [t,C,H,W] -> [t,K]
             logits_t = torch.cat(logits_list, dim=0).unsqueeze(0)  # [1,T,K]
             return logits_t.mean(1)  # [1,K]
         else:
@@ -40,10 +46,10 @@ def logits_mean_over_time(model, x, *, batch_size: int = 16):
     # 2) 5D: [B,C,T,H,W]
     if isinstance(x, torch.Tensor) and x.dim() == 5:
         B, C, T, H, W = x.shape
-        x_bt = x.permute(0, 2, 1, 3, 4).reshape(B*T, C, H, W)
+        x_bt = x.permute(0, 2, 1, 3, 4).reshape(B * T, C, H, W)
         logits_bt = []
-        for s in range(0, B*T, batch_size):
-            logits_bt.append(model(x_bt[s:s+batch_size]))  # [bs,K]
+        for s in range(0, B * T, batch_size):
+            logits_bt.append(model(x_bt[s : s + batch_size]))  # [bs,K]
         logits_bt = torch.cat(logits_bt, dim=0).view(B, T, -1)  # [B,T,K]
         return logits_bt.mean(1)  # [B,K]
 
@@ -56,7 +62,7 @@ def logits_mean_over_time(model, x, *, batch_size: int = 16):
             T = B_or_T
             logits_list = []
             for s in range(0, T, batch_size):
-                logits_list.append(model(x[s:s+batch_size]))  # [bs,K]
+                logits_list.append(model(x[s : s + batch_size]))  # [bs,K]
             logits_t = torch.cat(logits_list, dim=0).unsqueeze(0)  # [1,T,K]
             return logits_t.mean(1)  # [1,K]
         # ellers anta [B,C,H,W]
@@ -66,4 +72,6 @@ def logits_mean_over_time(model, x, *, batch_size: int = 16):
     if isinstance(x, torch.Tensor) and x.dim() == 3:
         return model(x.unsqueeze(0))  # [1,K]
 
-    raise ValueError(f"Ukjent input-shape til logits_mean_over_time: {getattr(x, 'shape', type(x))}")
+    raise ValueError(
+        f"Ukjent input-shape til logits_mean_over_time: {getattr(x, 'shape', type(x))}"
+    )


### PR DESCRIPTION
Justeringer for å få den enkleste modellen til å kjøre + ryddet opp litt.

config.py:
- organiserte variabler slik at det er samlet
- la til kommentarer

github/workflows/ci.yml
- sjekker formatteringer, ubrukte imports osv med ruff og black for hver pull request

src/datasets/__init__.py
- gjør at du slipper å referere til den indre fila datasets.py hver gang.

src/datasets/datasets.py
- denne koden ble utdelt til oss for å laste datasettene

src/main.py og src/utils/training_loop.py
- ryddet og fjernet unødvendige ting
- sørger for at de "samarbeider"

src/utils/video_utils.py
- inneholder hjelpefunksjonen logits_mean_over_time, som tar utdata fra en per-frame-modell og aggregerer logits over tid for å få én prediksjon per video.
 - Den håndterer flere mulige input-formater (list[T x [C,H,W]], [B,C,H,W], [B,C,T,H,W], osv.) og returnerer gjennomsnittet over tidsdimensjonen.

src/utils/model_factory.py
- lagt inn slik at det senere skal være enkelt å bytte mellom modellene