### PR TITLE
6 implement and test early fusion

### DIFF
--- a/config.py
+++ b/config.py
@@ -5,7 +5,7 @@ DATA_ROOT = "/dtu/datasets1/02516/ufc10"
 # DATA_ROOT = "/dtu/datasets1/02516/ucf101_noleakage" #til senere oppagve
 
 # models
-MODEL_NAMES = ["per_frame", "late_fusion"]
+MODEL_NAMES = ["per_frame", "late_fusion", "early_fusion"]
 # MODEL_NAMES = ["per_frame_agg", "early_fusion", "late_fusion", "c3d"]
 
 # antall klasser i datasettet

--- a/src/main.py
+++ b/src/main.py
@@ -7,7 +7,7 @@ from config import MODEL_NAMES
 from src.utils.training_loop import main as train_one_model
 
 if __name__ == "__main__":
-    # train_one_model("late_fusion")
+    # train_one_model("early_fusion")
     for name in MODEL_NAMES:
         print(f"\n[INFO] Starter trening for modell: {name}\n")
         train_one_model(name)

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -1,3 +1,4 @@
+import torch
 import torch.nn as nn
 from torchvision.models import resnet50, ResNet50_Weights
 
@@ -103,3 +104,111 @@ class LateFusionModel(nn.Module):
         logits_bt = self.head(feats_bt)  # [B*T, K]
         logits_bt = logits_bt.view(B, T, -1)  # [B, T, K]
         return logits_bt.mean(dim=1)  # late fusion (avg) -> [B, K]
+
+class EarlyFusionModel(nn.Module):
+    """
+    Early fusion for video:
+      - Konkatenér T frames på kanalaksen: [B,C,T,H,W] -> [B, C*T, H, W]
+      - 2D-ResNet50 (første conv utvides fra 3 -> 3*T inngangskanaler)
+      - Ett logits-output per video: [B, K]
+
+    Inndata støttes i to varianter:
+      - list/tuple med T tensors [B,C,H,W]
+      - stacket tensor [B,C,T,H,W]
+
+    Viktig: Bruk samme per-frame-transform som for SingleFrameModel.
+            (Dvs. normaliser hvert frame likt før stakking)
+    """
+
+    def __init__(
+        self,
+        num_classes: int,
+        freeze_backbone: bool = True,
+        dropout_p: float = 0.3,
+        weights=ResNet50_Weights.IMAGENET1K_V1,
+    ):
+        super().__init__()
+        m = resnet50(weights=weights)
+        feat_dim = m.fc.in_features
+        m.fc = nn.Identity()
+
+        # Frys/ikke frys backbone (vi setter requires_grad etter at conv1 ev. er utvidet)
+        self.backbone = m
+        self.head = nn.Sequential(
+            nn.Dropout(dropout_p),
+            nn.Linear(feat_dim, num_classes),
+        )
+        self._frozen = freeze_backbone  # brukes etter vi vet T
+
+    # ---- helpers ----
+    def _to_BCTHW(self, x):
+        """
+        Normaliser input til [B,C,T,H,W] og returner også B,C,T,H,W.
+        """
+        if isinstance(x, (list, tuple)):
+            assert len(x) > 0, "Tom sekvens av frames"
+            # x[t]: [B,C,H,W] — stack til [B,T,C,H,W] -> [B,C,T,H,W]
+            B, C, H, W = x[0].shape
+            T = len(x)
+            x_btc_hw = torch.stack(x, dim=1)           # [B,T,C,H,W]
+            x_bct_hw = x_btc_hw.permute(0, 2, 1, 3, 4) # [B,C,T,H,W]
+            return x_bct_hw, (B, C, T, H, W)
+        else:
+            # Forventet [B,C,T,H,W]
+            assert x.dim() == 5 and x.size(2) >= 1, "Forventet [B,C,T,H,W]"
+            B, C, T, H, W = x.shape
+            return x, (B, C, T, H, W)
+
+    def _ensure_conv1_in_channels(self, T: int, device, dtype):
+        """
+        Sørg for at første conv tar 3*T kanaler (early fusion).
+        Init: repeter IMAGENET-vektene over tidsdim og skaler med 1/T (gjennomsnitt).
+        Kalles første gang i forward når vi vet T.
+        """
+        conv1 = self.backbone.conv1
+        in_ch = conv1.in_channels
+        if in_ch == 3 * T:
+            return  # alt ok
+        assert in_ch == 3, f"Forventet opprinnelig conv1.in_channels=3, fikk {in_ch}"
+
+        # Lag en ny conv med 3*T inngangskanaler
+        new_conv = nn.Conv2d(
+            in_channels=3 * T,
+            out_channels=conv1.out_channels,
+            kernel_size=conv1.kernel_size,
+            stride=conv1.stride,
+            padding=conv1.padding,
+            bias=False,
+        ).to(device=device, dtype=dtype)
+
+        # Init-vekter: gjennomsnitt av RGB-vekter repetert T ganger
+        with torch.no_grad():
+            # conv1.weight: [out_ch, 3, kH, kW]
+            w = conv1.weight.to(device=device, dtype=dtype)
+            w_rep = w.repeat(1, T, 1, 1)  # [out_ch, 3*T, kH, kW]
+            # Del på T slik at energien per utkanal holder seg omtrent lik
+            new_conv.weight.copy_(w_rep / T)
+
+        self.backbone.conv1 = new_conv
+
+        # Re-frys/backbone om ønsket
+        for p in self.backbone.parameters():
+            p.requires_grad = not self._frozen
+
+    # ---- forward ----
+    def forward(self, x):
+        """
+        x: [B,C,T,H,W] eller list[T x [B,C,H,W]]
+        Returnerer: [B, num_classes]
+        """
+        x, (B, C, T, H, W) = self._to_BCTHW(x)           # [B,C,T,H,W]
+        self._ensure_conv1_in_channels(T, x.device, x.dtype)
+
+        # Early fusion: kanal-konkatenasjon
+        x_bct_hw = x
+        x_bct_hw = x_bct_hw.contiguous()
+        x_bct_hw = x_bct_hw.view(B, C * T, H, W)         # [B, C*T, H, W]
+
+        feats = self.backbone(x_bct_hw)                  # [B, F]
+        logits = self.head(feats)                        # [B, K]
+        return logits  

--- a/src/models/models.py
+++ b/src/models/models.py
@@ -105,6 +105,7 @@ class LateFusionModel(nn.Module):
         logits_bt = logits_bt.view(B, T, -1)  # [B, T, K]
         return logits_bt.mean(dim=1)  # late fusion (avg) -> [B, K]
 
+
 class EarlyFusionModel(nn.Module):
     """
     Early fusion for video:
@@ -150,8 +151,8 @@ class EarlyFusionModel(nn.Module):
             # x[t]: [B,C,H,W] — stack til [B,T,C,H,W] -> [B,C,T,H,W]
             B, C, H, W = x[0].shape
             T = len(x)
-            x_btc_hw = torch.stack(x, dim=1)           # [B,T,C,H,W]
-            x_bct_hw = x_btc_hw.permute(0, 2, 1, 3, 4) # [B,C,T,H,W]
+            x_btc_hw = torch.stack(x, dim=1)  # [B,T,C,H,W]
+            x_bct_hw = x_btc_hw.permute(0, 2, 1, 3, 4)  # [B,C,T,H,W]
             return x_bct_hw, (B, C, T, H, W)
         else:
             # Forventet [B,C,T,H,W]
@@ -201,14 +202,14 @@ class EarlyFusionModel(nn.Module):
         x: [B,C,T,H,W] eller list[T x [B,C,H,W]]
         Returnerer: [B, num_classes]
         """
-        x, (B, C, T, H, W) = self._to_BCTHW(x)           # [B,C,T,H,W]
+        x, (B, C, T, H, W) = self._to_BCTHW(x)  # [B,C,T,H,W]
         self._ensure_conv1_in_channels(T, x.device, x.dtype)
 
         # Early fusion: kanal-konkatenasjon
         x_bct_hw = x
         x_bct_hw = x_bct_hw.contiguous()
-        x_bct_hw = x_bct_hw.view(B, C * T, H, W)         # [B, C*T, H, W]
+        x_bct_hw = x_bct_hw.view(B, C * T, H, W)  # [B, C*T, H, W]
 
-        feats = self.backbone(x_bct_hw)                  # [B, F]
-        logits = self.head(feats)                        # [B, K]
-        return logits  
+        feats = self.backbone(x_bct_hw)  # [B, F]
+        logits = self.head(feats)  # [B, K]
+        return logits

--- a/src/utils/model_factory.py
+++ b/src/utils/model_factory.py
@@ -1,8 +1,4 @@
-from src.models.models import (
-    SingleFrameModel,
-    LateFusionModel,
-    EarlyFusionModel
-)  
+from src.models.models import SingleFrameModel, LateFusionModel, EarlyFusionModel
 
 
 def select_model(model_name: str, num_classes: int):
@@ -14,7 +10,7 @@ def select_model(model_name: str, num_classes: int):
 
     elif model_name == "late_fusion":
         return LateFusionModel(num_classes)
-    elif model_name == 'early_fusion':
+    elif model_name == "early_fusion":
         return EarlyFusionModel(num_classes)
     #     return EarlyFusionModel(num_classes)
     # elif model_name == 'c3d':

--- a/src/utils/model_factory.py
+++ b/src/utils/model_factory.py
@@ -1,7 +1,8 @@
 from src.models.models import (
     SingleFrameModel,
     LateFusionModel,
-)  # , LateFusionModel, EarlyFusionModel, C3D
+    EarlyFusionModel
+)  
 
 
 def select_model(model_name: str, num_classes: int):
@@ -13,8 +14,8 @@ def select_model(model_name: str, num_classes: int):
 
     elif model_name == "late_fusion":
         return LateFusionModel(num_classes)
-    # elif model_name == 'early_fusion':
-    #     # Instansier Early Fusion klassen
+    elif model_name == 'early_fusion':
+        return EarlyFusionModel(num_classes)
     #     return EarlyFusionModel(num_classes)
     # elif model_name == 'c3d':
     #     # Instansier 3D CNN klassen

--- a/src/utils/training_loop.py
+++ b/src/utils/training_loop.py
@@ -72,19 +72,15 @@ def make_datasets_and_loaders(model_name, tf, device):
     name = model_name.lower()
     pin = device.type == "cuda"
 
-    if name in ("late_fusion", "late-fusion"):
-        # Video-datasett (bruk stack_frames=True for enkelhets skyld)
-        train_ds = FrameVideoDataset(
-            DATA_ROOT, split="train", transform=tf, stack_frames=True
-        )
-        val_ds = FrameVideoDataset(
-            DATA_ROOT, split="val", transform=tf, stack_frames=True
-        )
-        bs = max(1, BATCH_SIZE // 4)  # video er tyngre
+    if name in ("late_fusion", "late-fusion", "early_fusion", "early-fusion"):
+        # Early/Late fusion trenger [B,C,T,H,W] (eller liste av T frames)
+        train_ds = FrameVideoDataset(DATA_ROOT, split="train", transform=tf, stack_frames=True)
+        val_ds   = FrameVideoDataset(DATA_ROOT, split="val",   transform=tf, stack_frames=True)
+        # Early fusion er tyngre (C*T inn i conv1) → senk batchstørrelse litt
+        bs = max(1, BATCH_SIZE // 4)
     else:
-        # Single frame
         train_ds = FrameImageDataset(DATA_ROOT, split="train", transform=tf)
-        val_ds = FrameImageDataset(DATA_ROOT, split="val", transform=tf)
+        val_ds   = FrameImageDataset(DATA_ROOT, split="val",   transform=tf)
         bs = BATCH_SIZE
 
     train_loader = DataLoader(

--- a/src/utils/training_loop.py
+++ b/src/utils/training_loop.py
@@ -74,13 +74,17 @@ def make_datasets_and_loaders(model_name, tf, device):
 
     if name in ("late_fusion", "late-fusion", "early_fusion", "early-fusion"):
         # Early/Late fusion trenger [B,C,T,H,W] (eller liste av T frames)
-        train_ds = FrameVideoDataset(DATA_ROOT, split="train", transform=tf, stack_frames=True)
-        val_ds   = FrameVideoDataset(DATA_ROOT, split="val",   transform=tf, stack_frames=True)
+        train_ds = FrameVideoDataset(
+            DATA_ROOT, split="train", transform=tf, stack_frames=True
+        )
+        val_ds = FrameVideoDataset(
+            DATA_ROOT, split="val", transform=tf, stack_frames=True
+        )
         # Early fusion er tyngre (C*T inn i conv1) → senk batchstørrelse litt
         bs = max(1, BATCH_SIZE // 4)
     else:
         train_ds = FrameImageDataset(DATA_ROOT, split="train", transform=tf)
-        val_ds   = FrameImageDataset(DATA_ROOT, split="val",   transform=tf)
+        val_ds = FrameImageDataset(DATA_ROOT, split="val", transform=tf)
         bs = BATCH_SIZE
 
     train_loader = DataLoader(

--- a/src/utils/video_utils.py
+++ b/src/utils/video_utils.py
@@ -1,7 +1,8 @@
 # src/utils/video_utils.py
 import torch
 
-#kun for smoke_test, kan slette denne etterhvert
+# kun for smoke_test, kan slette denne etterhvert
+
 
 @torch.no_grad()
 def logits_mean_over_time(model, x, *, batch_size: int = 16):

--- a/src/utils/video_utils.py
+++ b/src/utils/video_utils.py
@@ -1,6 +1,7 @@
 # src/utils/video_utils.py
 import torch
 
+#kun for smoke_test, kan slette denne etterhvert
 
 @torch.no_grad()
 def logits_mean_over_time(model, x, *, batch_size: int = 16):


### PR DESCRIPTION
- la til early fusion modell og gjorde små justeringer slik at den kan trene på samme måte som de andre
testet med å trene den alene + sammen med de andre med 1 epoch

config.py
- la til early_fusion som alternativ

src/models/models.py
- her er det lagt til selve early fusion klassen

src/utils/model_factory.py
- initalisering av modellen

src/utils/training_loop.py
- justering i treningsloopen sånn at det skal gå overens med video (samme måte som late_fusion)